### PR TITLE
デフォルトウィンドウ幅でのコピーボタン表示問題を修正

### DIFF
--- a/src/components/home/ClipboardItemList.tsx
+++ b/src/components/home/ClipboardItemList.tsx
@@ -117,12 +117,12 @@ export function ClipboardItemList({
             className="mb-1 p-3 hover:bg-accent hover:text-accent-foreground transition-colors border hover:border-accent-foreground/20 group"
             onContextMenu={(e) => onContextMenu(e, item)}
           >
-            <div className="flex items-start gap-3">
-              <div className="flex-shrink-0 mt-0.5">
+            <div className="grid grid-cols-[auto_1fr_auto] gap-3 items-start">
+              <div className="mt-0.5">
                 <span className="text-xs">{getTypeIcon(currentFormat)}</span>
               </div>
 
-              <div className="flex-1 min-w-0 cursor-default text-left" onClick={() => onItemClick(item.id)}>
+              <div className="min-w-0 cursor-default text-left" onClick={() => onItemClick(item.id)}>
                 <div className="flex items-center gap-2 mb-1">
                   <Hash className="h-3 w-3 text-muted-foreground" />
                   <span className="text-xs font-mono text-muted-foreground">{index + 1}</span>
@@ -188,7 +188,7 @@ export function ClipboardItemList({
                 )}
               </div>
 
-              <div className="flex-shrink-0 ml-2">
+              <div className="ml-2">
                 <Button
                   variant="ghost"
                   size="icon"

--- a/src/components/home/ClipboardItemList.tsx
+++ b/src/components/home/ClipboardItemList.tsx
@@ -192,7 +192,7 @@ export function ClipboardItemList({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-6 w-6 hover:bg-accent opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                  className="h-6 w-6 hover:bg-accent transition-opacity cursor-pointer"
                   onClick={(e) => {
                     e.stopPropagation();
                     navigator.clipboard.writeText(currentContent);


### PR DESCRIPTION
## 概要
デフォルトウィンドウ幅でクリップボードアイテムのコピーボタンが表示されない問題を修正し、UXを改善

## 問題
- デフォルトのウィンドウ幅でコピーボタンが見切れて表示されない
- ホバー時のみ表示で発見しにくい
- Flexboxレイアウトでコンテンツが全幅を取得し、ボタンが押し出される

## 解決策

### 1. FlexboxからGrid Layoutに変更
Flexboxの代わりにGrid Layoutを使用してコピーボタンの領域を確実に確保

**Grid構成:**
- **1列目 (auto)**: アイコン - 内容に応じた最小幅
- **2列目 (1fr)**: メインコンテンツ - 残り全幅使用
- **3列目 (auto)**: コピーボタン - 固定幅確保

### 2. コピーボタンを常時表示に変更
opacity-0 group-hover:opacity-100を削除して常時表示に変更

## コミット
1. **Grid Layout実装** (89a3305): Flexbox→Gridでレイアウト修正
2. **常時表示化** (f90ed95): ホバー時のみ→常時表示でUX改善

## テスト
- [x] TypeScriptコンパイル確認
- [x] Rustコンパイル確認
- [x] Grid Layoutでレイアウト崩れなし
- [x] コピーボタンが常時表示

## 期待効果
- ✅ 狭いウィンドウでもコピーボタン確実表示
- ✅ UX向上（ボタンの発見しやすさ）
- ✅ アクセシビリティ改善
- ✅ レスポンシブ対応

## 関連
Closes #19

🤖 Generated with [Claude Code](https://claude.ai/code)