### PR TITLE
画像コピーのキャプチャーと表示機能の実装

### DIFF
--- a/src-tauri/src/commands/clipboard.rs
+++ b/src-tauri/src/commands/clipboard.rs
@@ -1,8 +1,8 @@
 use crate::database::{Database, DisplayClipboardItem};
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use clipboard_rs::{
-    Clipboard, ClipboardContext, ClipboardHandler, ClipboardWatcher, ClipboardWatcherContext,
-    ContentFormat, common::RustImage,
+    common::RustImage, Clipboard, ClipboardContext, ClipboardHandler, ClipboardWatcher,
+    ClipboardWatcherContext, ContentFormat,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -56,10 +56,10 @@ impl ClipboardHandler for ClipboardManager {
 
         // 全ての利用可能な形式を収集
         let all_format_contents = collect_all_format_contents(&ctx);
-        
+
         // 利用可能な形式のリストを作成
         let available_formats: Vec<String> = all_format_contents.keys().cloned().collect();
-        
+
         // 優先順位に従ってコンテンツを取得
         let (current_content, detected_format) = match get_clipboard_content_by_priority(&ctx) {
             Ok(content_info) => content_info,
@@ -70,7 +70,7 @@ impl ClipboardHandler for ClipboardManager {
                     Ok(text) => {
                         println!("⚠️ フォールバック: テキストとして取得");
                         (text, "text/plain".to_string())
-                    },
+                    }
                     Err(text_err) => {
                         eprintln!("❌ フォールバック失敗: {}", text_err);
                         return;
@@ -95,7 +95,7 @@ impl ClipboardHandler for ClipboardManager {
             }
             &current_content[..boundary]
         };
-        
+
         println!("📝 新しい内容: {}", preview);
         self.last_content = current_content.clone();
 
@@ -123,11 +123,11 @@ impl ClipboardHandler for ClipboardManager {
                 };
 
                 // 正規化されたデータベースではコンテンツの重複チェック方法が異なる
-                let is_duplicate = recent_items
-                    .iter()
-                    .any(|item| {
-                        item.contents.iter().any(|content| content.content == content_clone)
-                    });
+                let is_duplicate = recent_items.iter().any(|item| {
+                    item.contents
+                        .iter()
+                        .any(|content| content.content == content_clone)
+                });
 
                 if !is_duplicate {
                     match db
@@ -137,7 +137,7 @@ impl ClipboardHandler for ClipboardManager {
                             Some("clipboard-rs"),
                             &formats_clone,
                             &format_clone,
-                            &contents_clone
+                            &contents_clone,
                         )
                         .await
                     {
@@ -215,7 +215,9 @@ pub async fn check_duplicate_content(
 
     // 正規化されたデータベースでの重複チェック
     let is_duplicate = recent_items.iter().any(|item| {
-        item.contents.iter().any(|content_item| content_item.content == content)
+        item.contents
+            .iter()
+            .any(|content_item| content_item.content == content)
     });
     Ok(is_duplicate)
 }
@@ -393,7 +395,7 @@ pub async fn clear_clipboard_text() -> Result<(), String> {
 /// クリップボードで利用可能な形式を検出
 fn detect_clipboard_formats(ctx: &ClipboardContext) -> Vec<String> {
     let mut formats = Vec::new();
-    
+
     if ctx.has(ContentFormat::Text) {
         formats.push("text/plain".to_string());
     }
@@ -409,14 +411,16 @@ fn detect_clipboard_formats(ctx: &ClipboardContext) -> Vec<String> {
     if ctx.has(ContentFormat::Files) {
         formats.push("application/x-file-list".to_string());
     }
-    
+
     formats
 }
 
 /// 全ての利用可能な形式のコンテンツを収集
-fn collect_all_format_contents(ctx: &ClipboardContext) -> std::collections::HashMap<String, String> {
+fn collect_all_format_contents(
+    ctx: &ClipboardContext,
+) -> std::collections::HashMap<String, String> {
     let mut contents = std::collections::HashMap::new();
-    
+
     // テキスト形式
     if ctx.has(ContentFormat::Text) {
         if let Ok(text) = ctx.get_text() {
@@ -424,7 +428,7 @@ fn collect_all_format_contents(ctx: &ClipboardContext) -> std::collections::Hash
             contents.insert(format, text);
         }
     }
-    
+
     // ファイルリスト形式
     if ctx.has(ContentFormat::Files) {
         if let Ok(files) = ctx.get_files() {
@@ -432,13 +436,13 @@ fn collect_all_format_contents(ctx: &ClipboardContext) -> std::collections::Hash
             contents.insert("application/x-file-list".to_string(), files_text);
         }
     }
-    
+
     // 画像形式
     if ctx.has(ContentFormat::Image) {
         if let Ok(image_data) = ctx.get_image() {
             // RustImageDataの利用可能なメソッドを試してみる
             println!("📸 画像データ取得成功");
-            
+
             // 画像をファイルに一時保存して読み込む方法を試す
             let temp_path = std::env::temp_dir().join("clipboard_debug.png");
             match image_data.save_to_path(&temp_path.to_string_lossy()) {
@@ -449,8 +453,15 @@ fn collect_all_format_contents(ctx: &ClipboardContext) -> std::collections::Hash
                             // 画像サイズ制限（5MB）
                             const MAX_IMAGE_SIZE: usize = 5 * 1024 * 1024;
                             if bytes.len() > MAX_IMAGE_SIZE {
-                                println!("📸 画像サイズが大きすぎます: {}バイト (上限: {}MB)", bytes.len(), MAX_IMAGE_SIZE / 1024 / 1024);
-                                let size_info = format!("[画像データ: {}KB - サイズ制限により表示不可]", bytes.len() / 1024);
+                                println!(
+                                    "📸 画像サイズが大きすぎます: {}バイト (上限: {}MB)",
+                                    bytes.len(),
+                                    MAX_IMAGE_SIZE / 1024 / 1024
+                                );
+                                let size_info = format!(
+                                    "[画像データ: {}KB - サイズ制限により表示不可]",
+                                    bytes.len() / 1024
+                                );
                                 contents.insert("image/png".to_string(), size_info);
                             } else {
                                 let base64_data = BASE64.encode(&bytes);
@@ -458,10 +469,10 @@ fn collect_all_format_contents(ctx: &ClipboardContext) -> std::collections::Hash
                                 contents.insert("image/png".to_string(), data_url);
                                 println!("📸 画像データ保存成功: {}KB", bytes.len() / 1024);
                             }
-                            
+
                             // 一時ファイル削除
                             let _ = std::fs::remove_file(&temp_path);
-                        },
+                        }
                         Err(e) => {
                             println!("ファイル読み込みエラー: {}", e);
                             // Windows特有のエラーでもプレースホルダー保存
@@ -469,9 +480,12 @@ fn collect_all_format_contents(ctx: &ClipboardContext) -> std::collections::Hash
                             contents.insert("image/png".to_string(), error_info);
                         }
                     }
-                },
+                }
                 Err(e) => {
-                    println!("画像保存エラー: {} (Windows OSError(0)は正常終了の場合があります)", e);
+                    println!(
+                        "画像保存エラー: {} (Windows OSError(0)は正常終了の場合があります)",
+                        e
+                    );
                     // Windows特有のOSError(0)の場合でもプレースホルダー保存
                     if e.to_string().contains("OSError(0)") {
                         let placeholder = "[画像データ: Windows取得エラー]".to_string();
@@ -480,25 +494,25 @@ fn collect_all_format_contents(ctx: &ClipboardContext) -> std::collections::Hash
                         let error_info = format!("[画像データ: 保存エラー - {}]", e);
                         contents.insert("image/png".to_string(), error_info);
                     }
-                },
+                }
             }
         }
     }
-    
+
     // RTF形式
     if ctx.has(ContentFormat::Rtf) {
         if let Ok(rtf) = ctx.get_rich_text() {
             contents.insert("text/rtf".to_string(), rtf);
         }
     }
-    
+
     // HTML形式
     if ctx.has(ContentFormat::Html) {
         if let Ok(html) = ctx.get_html() {
             contents.insert("text/html".to_string(), html);
         }
     }
-    
+
     contents
 }
 
@@ -506,31 +520,33 @@ fn collect_all_format_contents(ctx: &ClipboardContext) -> std::collections::Hash
 fn get_clipboard_content_by_priority(ctx: &ClipboardContext) -> Result<(String, String), String> {
     // 優先順位: Text > Files > Image > RTF > HTML
     // Textを最優先にすることで、URLなどが適切に判定される
-    
+
     // 最優先: テキスト（URLやプレーンテキストを適切に処理）
     if ctx.has(ContentFormat::Text) {
-        let text = ctx.get_text().map_err(|e| format!("テキスト取得エラー: {}", e))?;
+        let text = ctx
+            .get_text()
+            .map_err(|e| format!("テキスト取得エラー: {}", e))?;
         // テキストの内容を詳細分析してより正確な形式判定
         let format = analyze_text_format(&text);
         return Ok((text, format));
     }
-    
+
     if ctx.has(ContentFormat::Files) {
         match ctx.get_files() {
             Ok(files) => {
                 let files_text = files.join("\n");
                 return Ok((files_text, "application/x-file-list".to_string()));
-            },
+            }
             Err(e) => println!("ファイルリスト取得エラー: {}", e),
         }
     }
-    
+
     if ctx.has(ContentFormat::Image) {
         match ctx.get_image() {
             Ok(image_data) => {
                 // RustImageDataの利用可能なメソッドを試してみる
                 println!("📸 画像データ取得成功");
-                
+
                 // 画像をファイルに一時保存して読み込む方法を試す
                 let temp_path = std::env::temp_dir().join("clipboard_priority_debug.png");
                 match image_data.save_to_path(&temp_path.to_string_lossy()) {
@@ -541,56 +557,75 @@ fn get_clipboard_content_by_priority(ctx: &ClipboardContext) -> Result<(String, 
                                 // 画像サイズ制限（5MB）
                                 const MAX_IMAGE_SIZE: usize = 5 * 1024 * 1024;
                                 if bytes.len() > MAX_IMAGE_SIZE {
-                                    println!("📸 画像サイズが大きすぎます: {}バイト (上限: {}MB)", bytes.len(), MAX_IMAGE_SIZE / 1024 / 1024);
-                                    let size_info = format!("[画像データ: {}KB - サイズ制限により表示不可]", bytes.len() / 1024);
-                                    
+                                    println!(
+                                        "📸 画像サイズが大きすぎます: {}バイト (上限: {}MB)",
+                                        bytes.len(),
+                                        MAX_IMAGE_SIZE / 1024 / 1024
+                                    );
+                                    let size_info = format!(
+                                        "[画像データ: {}KB - サイズ制限により表示不可]",
+                                        bytes.len() / 1024
+                                    );
+
                                     // 一時ファイル削除
                                     let _ = std::fs::remove_file(&temp_path);
-                                    
+
                                     return Ok((size_info, "image/png".to_string()));
                                 } else {
                                     let base64_data = BASE64.encode(&bytes);
                                     let data_url = format!("data:image/png;base64,{}", base64_data);
                                     println!("📸 画像データ変換成功: {}KB", bytes.len() / 1024);
-                                    
+
                                     // 一時ファイル削除
                                     let _ = std::fs::remove_file(&temp_path);
-                                    
+
                                     return Ok((data_url, "image/png".to_string()));
                                 }
-                            },
+                            }
                             Err(e) => {
                                 println!("ファイル読み込みエラー: {}", e);
-                                return Ok(("[画像データ: 読み込みエラー]".to_string(), "image/png".to_string()));
-                            },
+                                return Ok((
+                                    "[画像データ: 読み込みエラー]".to_string(),
+                                    "image/png".to_string(),
+                                ));
+                            }
                         }
-                    },
+                    }
                     Err(e) => {
                         println!("画像保存エラー: {}", e);
-                        return Ok(("[画像データ: 保存エラー]".to_string(), "image/png".to_string()));
-                    },
+                        return Ok((
+                            "[画像データ: 保存エラー]".to_string(),
+                            "image/png".to_string(),
+                        ));
+                    }
                 }
-            },
+            }
             Err(e) => {
-                println!("画像取得エラー: {} (Windows OSError(0)は正常終了の場合があります)", e);
+                println!(
+                    "画像取得エラー: {} (Windows OSError(0)は正常終了の場合があります)",
+                    e
+                );
                 // Windows特有のOSError(0)の場合、画像が実際に存在する可能性があるため
                 // プレースホルダーとして画像形式で保存
                 if e.to_string().contains("OSError(0)") {
                     println!("📸 Windows OSError(0) - 画像データは存在する可能性があります");
                     println!("💡 clipboard-rsの制限: 将来的にarboardライブラリへの移行を検討");
-                    return Ok(("[画像データ: Windows取得エラー - arboard移行検討中]".to_string(), "image/png".to_string()));
+                    return Ok((
+                        "[画像データ: Windows取得エラー - arboard移行検討中]".to_string(),
+                        "image/png".to_string(),
+                    ));
                 }
-            },
+            }
         }
     }
-    
+
     if ctx.has(ContentFormat::Rtf) {
         match ctx.get_rich_text() {
             Ok(rtf) => return Ok((rtf, "text/rtf".to_string())),
             Err(e) => println!("RTF取得エラー: {}", e),
         }
     }
-    
+
     // 最低優先度: HTML（現在パース機能なし）
     if ctx.has(ContentFormat::Html) {
         match ctx.get_html() {
@@ -598,7 +633,7 @@ fn get_clipboard_content_by_priority(ctx: &ClipboardContext) -> Result<(String, 
             Err(e) => println!("HTML取得エラー: {}", e),
         }
     }
-    
+
     Err("利用可能なクリップボード形式がありません".to_string())
 }
 

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -39,17 +39,23 @@ pub async fn search_clipboard_history(
 ) -> Result<Vec<DisplayClipboardItem>, String> {
     let db = db_state.lock().await;
     // 正規化された検索結果をDisplayClipboardItemに変換
-    let search_results = db.search_history(&query, limit).await
+    let search_results = db
+        .search_history(&query, limit)
+        .await
         .map_err(|e| format!("履歴検索エラー: {}", e))?;
-    
+
     let mut display_results = Vec::new();
     for item in search_results {
-        let available_formats: Vec<String> = item.contents.iter().map(|c| c.format.clone()).collect();
-        let format_contents: std::collections::HashMap<String, String> = item.contents.iter()
+        let available_formats: Vec<String> =
+            item.contents.iter().map(|c| c.format.clone()).collect();
+        let format_contents: std::collections::HashMap<String, String> = item
+            .contents
+            .iter()
             .map(|c| (c.format.clone(), c.content.clone()))
             .collect();
-        
-        let primary_content = format_contents.get(&item.primary_format)
+
+        let primary_content = format_contents
+            .get(&item.primary_format)
             .cloned()
             .unwrap_or_else(|| "[No content]".to_string());
 
@@ -65,7 +71,7 @@ pub async fn search_clipboard_history(
             format_contents: Some(format_contents),
         });
     }
-    
+
     Ok(display_results)
 }
 

--- a/src/components/home/ClipboardContentRenderer.tsx
+++ b/src/components/home/ClipboardContentRenderer.tsx
@@ -1,0 +1,124 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { parseFileList, truncateText } from "@/utils/textUtils";
+import { useImageWindow } from "@/hooks/useImageWindow";
+
+interface ClipboardContentRendererProps {
+  format: string;
+  content: string;
+  isExpanded: boolean;
+}
+
+export function ClipboardContentRenderer({
+  format,
+  content,
+  isExpanded,
+}: ClipboardContentRendererProps) {
+  const { showImageWindow } = useImageWindow();
+  
+  const shouldTruncate = content.length > 100;
+  const displayContent = isExpanded || !shouldTruncate ? content : truncateText(content);
+
+  // URL表示 - クリック可能なリンク
+  if (format === "text/uri-list") {
+    return (
+      <div className="text-sm">
+        <button
+          type="button"
+          className="text-blue-500 hover:text-blue-700 underline break-words cursor-pointer text-left w-full"
+          onClick={async (e) => {
+            e.stopPropagation();
+            try {
+              await openUrl(content.trim());
+            } catch (error) {
+              console.error("URL開く失敗:", error);
+            }
+          }}
+          title={`${content} を外部ブラウザで開く`}
+        >
+          {displayContent}
+        </button>
+      </div>
+    );
+  }
+
+  // ファイルリスト表示 - アイコン付きリスト
+  if (format === "application/x-file-list") {
+    const fileList = parseFileList(content);
+    const displayFiles = isExpanded ? fileList : fileList.slice(0, 3);
+    
+    return (
+      <div className="text-sm space-y-1">
+        {displayFiles.map((file, i) => (
+          <div key={`${file.filename}-${i}`} className="flex items-center gap-2">
+            <span className="text-base">{file.icon}</span>
+            <span className="break-words">{file.filename}</span>
+          </div>
+        ))}
+        {!isExpanded && fileList.length > 3 && (
+          <div className="text-xs text-muted-foreground">
+            +{fileList.length - 3}個のファイル...
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // 画像表示
+  if (format === "image/png") {
+    return (
+      <div className="text-sm">
+        {content.startsWith("data:image/") ? (
+          <div className="space-y-2">
+            <img
+              src={content}
+              alt="クリップボード画像"
+              className="max-w-full max-h-48 rounded border object-contain bg-muted cursor-pointer transition-all hover:opacity-80"
+              onClick={(e) => {
+                e.stopPropagation();
+                console.log(
+                  "🖼️ 画像クリック - クリック位置表示:",
+                  format,
+                  "データ長:",
+                  content.length,
+                  "位置:",
+                  e.screenX,
+                  e.screenY
+                );
+                showImageWindow(content, e);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  // キーボード操作の場合は画面中央に表示
+                  const centerEvent = {
+                    screenX: window.screen.availWidth / 2,
+                    screenY: window.screen.availHeight / 2,
+                  } as React.MouseEvent;
+                  showImageWindow(content, centerEvent);
+                }
+              }}
+              onError={(e) => {
+                console.error("画像表示エラー:", e);
+                e.currentTarget.style.display = "none";
+              }}
+              title="クリックで別ウィンドウ表示"
+            />
+            <p className="text-xs text-muted-foreground">
+              画像データ ({Math.round(content.length / 1024)}KB)
+            </p>
+          </div>
+        ) : (
+          <p className="text-muted-foreground">{displayContent}</p>
+        )}
+      </div>
+    );
+  }
+
+  // 通常のテキスト表示
+  return (
+    <p className="text-sm leading-relaxed break-words whitespace-pre-wrap">
+      {displayContent}
+    </p>
+  );
+}

--- a/src/components/home/ClipboardContentRenderer.tsx
+++ b/src/components/home/ClipboardContentRenderer.tsx
@@ -1,6 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { parseFileList, truncateText } from "@/utils/textUtils";
 import { useImageWindow } from "@/hooks/useImageWindow";
+import { useClipboardControl } from "@/hooks/useClipboardControl";
 
 interface ClipboardContentRendererProps {
   format: string;
@@ -14,6 +15,7 @@ export function ClipboardContentRenderer({
   isExpanded,
 }: ClipboardContentRendererProps) {
   const { showImageWindow } = useImageWindow();
+  const { notifyStartCopy } = useClipboardControl();
   
   const shouldTruncate = content.length > 100;
   const displayContent = isExpanded || !shouldTruncate ? content : truncateText(content);
@@ -27,6 +29,8 @@ export function ClipboardContentRenderer({
           className="text-blue-500 hover:text-blue-700 underline break-words cursor-pointer text-left w-full"
           onClick={async (e) => {
             e.stopPropagation();
+            // URL開く際の通知（URLがクリップボードにコピーされる可能性があるため）
+            await notifyStartCopy(content.trim(), "url-open");
             try {
               await openUrl(content.trim());
             } catch (error) {

--- a/src/components/home/ClipboardItem.tsx
+++ b/src/components/home/ClipboardItem.tsx
@@ -5,6 +5,8 @@ import { FormatBadges } from "@/components/ui/format-badges";
 import type { DisplayClipboardItem } from "@/types/clipboardActions";
 import { formatRelativeTime } from "@/utils/dateUtils";
 import { getTypeIcon, getTypeName } from "@/utils/textUtils";
+import { useImageCopy } from "@/hooks/useImageCopy";
+import { useTextCopy } from "@/hooks/useTextCopy";
 import { ClipboardContentRenderer } from "./ClipboardContentRenderer";
 
 interface ClipboardItemProps {
@@ -28,6 +30,8 @@ export function ClipboardItem({
   onFormatChange,
   onContextMenu,
 }: ClipboardItemProps) {
+  const { copyImageToClipboard } = useImageCopy();
+  const { copyTextToClipboard } = useTextCopy();
   return (
     <Card
       key={item.id}
@@ -79,11 +83,21 @@ export function ClipboardItem({
             variant="ghost"
             size="icon"
             className="h-6 w-6 hover:bg-accent transition-opacity cursor-pointer"
-            onClick={(e) => {
+            onClick={async (e) => {
               e.stopPropagation();
-              navigator.clipboard.writeText(currentContent);
+              
+              // 画像データの場合は画像としてコピー、それ以外はテキストとしてコピー
+              if (currentFormat === "image/png" && currentContent.startsWith("data:image/")) {
+                await copyImageToClipboard(currentContent);
+              } else {
+                await copyTextToClipboard(currentContent);
+              }
             }}
-            title="クリップボードにコピー"
+            title={
+              currentFormat === "image/png" && currentContent.startsWith("data:image/")
+                ? "画像をクリップボードにコピー"
+                : "テキストをクリップボードにコピー"
+            }
           >
             <Copy className="h-3 w-3" />
           </Button>

--- a/src/components/home/ClipboardItem.tsx
+++ b/src/components/home/ClipboardItem.tsx
@@ -1,0 +1,94 @@
+import { Clock, Copy, Hash } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { FormatBadges } from "@/components/ui/format-badges";
+import type { DisplayClipboardItem } from "@/types/clipboardActions";
+import { formatRelativeTime } from "@/utils/dateUtils";
+import { getTypeIcon, getTypeName } from "@/utils/textUtils";
+import { ClipboardContentRenderer } from "./ClipboardContentRenderer";
+
+interface ClipboardItemProps {
+  item: DisplayClipboardItem;
+  index: number;
+  isExpanded: boolean;
+  currentFormat: string;
+  currentContent: string;
+  onItemClick: (itemId: string) => void;
+  onFormatChange: (itemId: string, format: string) => void;
+  onContextMenu: (e: React.MouseEvent, item: DisplayClipboardItem) => void;
+}
+
+export function ClipboardItem({
+  item,
+  index,
+  isExpanded,
+  currentFormat,
+  currentContent,
+  onItemClick,
+  onFormatChange,
+  onContextMenu,
+}: ClipboardItemProps) {
+  return (
+    <Card
+      key={item.id}
+      className="mb-1 p-3 hover:bg-accent hover:text-accent-foreground transition-colors border hover:border-accent-foreground/20 group"
+      onContextMenu={(e) => onContextMenu(e, item)}
+    >
+      <div className="grid grid-cols-[auto_1fr_auto] gap-3 items-start">
+        <div className="mt-0.5">
+          <span className="text-xs">{getTypeIcon(currentFormat)}</span>
+        </div>
+
+        <button
+          type="button"
+          className="min-w-0 cursor-default text-left bg-transparent border-none p-0 w-full"
+          onClick={() => onItemClick(item.id)}
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <Hash className="h-3 w-3 text-muted-foreground" />
+            <span className="text-xs font-mono text-muted-foreground">{index + 1}</span>
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              {formatRelativeTime(item.timestamp)}
+            </div>
+            <span className="text-xs px-1.5 py-0.5 bg-muted rounded text-muted-foreground">
+              {getTypeName(currentFormat)}
+            </span>
+          </div>
+
+          {/* 複数形式バッジ */}
+          {item.available_formats && (
+            <FormatBadges
+              availableFormats={item.available_formats}
+              currentFormat={currentFormat}
+              onFormatChange={(format) => onFormatChange(item.id, format)}
+              mainFormat={item.content_type}
+            />
+          )}
+
+          {/* コンテンツ表示 - 形式別の特殊表示 */}
+          <ClipboardContentRenderer
+            format={currentFormat}
+            content={currentContent}
+            isExpanded={isExpanded}
+          />
+        </button>
+
+        <div className="ml-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 hover:bg-accent transition-opacity cursor-pointer"
+            onClick={(e) => {
+              e.stopPropagation();
+              navigator.clipboard.writeText(currentContent);
+            }}
+            title="クリップボードにコピー"
+          >
+            <Copy className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/home/ClipboardItemList.tsx
+++ b/src/components/home/ClipboardItemList.tsx
@@ -1,13 +1,7 @@
-import { invoke } from "@tauri-apps/api/core";
-import { openUrl } from "@tauri-apps/plugin-opener";
-import { Clock, Copy, Hash } from "lucide-react";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import { FormatBadges } from "@/components/ui/format-badges";
 import type { DisplayClipboardItem } from "@/types/clipboardActions";
-import { formatRelativeTime } from "@/utils/dateUtils";
-import { getTypeIcon, getTypeName, parseFileList, truncateText } from "@/utils/textUtils";
+import { useClipboardFormats } from "@/hooks/useClipboardFormats";
+import { ClipboardItem } from "./ClipboardItem";
+import { ErrorView, LoadingView, EmptyView } from "./ClipboardStateViews";
 
 interface ClipboardItemListProps {
   clipboardItems: DisplayClipboardItem[];
@@ -28,189 +22,19 @@ export function ClipboardItemList({
   onHistoryReload,
   onContextMenu,
 }: ClipboardItemListProps) {
-  // 各アイテムの選択された形式を管理
-  const [selectedFormats, setSelectedFormats] = useState<Record<string, string>>({});
+  const { handleFormatChange, getCurrentFormatAndContent } = useClipboardFormats();
 
-  // 形式切り替えハンドラー
-  const handleFormatChange = (itemId: string, format: string) => {
-    setSelectedFormats((prev) => ({
-      ...prev,
-      [itemId]: format,
-    }));
-  };
-
-  // アイテムの現在の形式とコンテンツを取得
-  const getCurrentFormatAndContent = (item: DisplayClipboardItem) => {
-    const selectedFormat = selectedFormats[item.id] || item.content_type;
-    const content = item.format_contents?.[selectedFormat] || item.content;
-    return { format: selectedFormat, content };
-  };
-
-  // 画像をクリック位置に表示
-  const handleImageWindow = (imageData: string, clickEvent: React.MouseEvent) => {
-    console.log("🖼️ 画像表示:", `${imageData.substring(0, 50)}...`);
-
-    // 画像サイズを取得するための一時的なImage要素を作成
-    const tempImg = new Image();
-    tempImg.onload = () => {
-      const imgWidth = tempImg.width;
-      const imgHeight = tempImg.height;
-
-      // デスクトップサイズを取得
-      const screenWidth = window.screen.availWidth;
-      const screenHeight = window.screen.availHeight;
-
-      // ウィンドウサイズを計算（画像サイズに合わせる、ただしデスクトップサイズを超える場合は縮小）
-      let windowWidth = imgWidth;
-      let windowHeight = imgHeight;
-
-      // デスクトップサイズの90%を最大値とする
-      const maxWidth = screenWidth * 0.9;
-      const maxHeight = screenHeight * 0.9;
-
-      // 縦横どちらかがデスクトップサイズを超える場合、アスペクト比を維持して縮小
-      if (windowWidth > maxWidth || windowHeight > maxHeight) {
-        const scaleWidth = maxWidth / windowWidth;
-        const scaleHeight = maxHeight / windowHeight;
-        const scale = Math.min(scaleWidth, scaleHeight); // より小さいスケールを選択
-
-        windowWidth = windowWidth * scale;
-        windowHeight = windowHeight * scale;
-      }
-
-      // クリック位置を基準とした表示位置を計算
-      const clickX = clickEvent.screenX;
-      const clickY = clickEvent.screenY;
-      
-      // ウィンドウがデスクトップ範囲外に出ないよう調整
-      let windowX = clickX - windowWidth / 2; // クリック位置を中央とする
-      let windowY = clickY - windowHeight / 2;
-      
-      // 画面境界チェック
-      if (windowX < 0) windowX = 0;
-      if (windowY < 0) windowY = 0;
-      if (windowX + windowWidth > screenWidth) {
-        windowX = screenWidth - windowWidth;
-      }
-      if (windowY + windowHeight > screenHeight) {
-        windowY = screenHeight - windowHeight;
-      }
-      
-      // 調整後もデスクトップ範囲外になる場合は中央表示にフォールバック
-      if (windowX < 0 || windowY < 0) {
-        windowX = (screenWidth - windowWidth) / 2;
-        windowY = (screenHeight - windowHeight) / 2;
-      }
-
-      const newWindow = window.open(
-        "",
-        "_blank",
-        `width=${Math.round(windowWidth)},height=${Math.round(windowHeight)},left=${Math.round(windowX)},top=${Math.round(windowY)},scrollbars=no,resizable=yes`,
-      );
-      if (newWindow) {
-        newWindow.document.write(`
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <title>ClipOne - 画像表示</title>
-            <style>
-              body { 
-                margin: 0; 
-                background: #000; 
-                display: flex; 
-                justify-content: center; 
-                align-items: center; 
-                min-height: 100vh;
-                overflow: hidden;
-              }
-              img { 
-                max-width: 100vw; 
-                max-height: 100vh; 
-                object-fit: contain;
-                cursor: pointer;
-              }
-            </style>
-          </head>
-          <body>
-            <img src="${imageData}" alt="クリップボード画像" onclick="window.close()" />
-            <script>
-              document.addEventListener('keydown', function(event) {
-                if (event.key === 'Escape') {
-                  window.close();
-                }
-              });
-              
-              document.addEventListener('click', function(event) {
-                window.close();
-              });
-            </script>
-          </body>
-          </html>
-        `);
-        newWindow.document.close();
-      } else {
-        console.error("❌ 別ウィンドウを開けませんでした（ポップアップブロックされた可能性があります）");
-      }
-    };
-
-    tempImg.src = imageData;
-  };
-
-  const handleAddTestData = async () => {
-    try {
-      const result = await invoke("add_test_data");
-      console.log("テストデータ追加結果:", result);
-      await onHistoryReload();
-    } catch (err) {
-      console.error("テストデータ追加エラー:", err);
-    }
-  };
 
   if (error) {
-    return (
-      <div className="p-2">
-        <Card className="mb-2 p-3 border-red-200 bg-red-50 text-red-800">
-          <p className="text-sm">{error}</p>
-          <div className="flex gap-2 mt-2">
-            <Button variant="outline" size="sm" onClick={onHistoryReload}>
-              再試行
-            </Button>
-            {process.env.NODE_ENV === "development" && (
-              <Button variant="outline" size="sm" onClick={handleAddTestData}>
-                テストデータ追加
-              </Button>
-            )}
-          </div>
-        </Card>
-      </div>
-    );
+    return <ErrorView error={error} onHistoryReload={onHistoryReload} />;
   }
 
   if (loading) {
-    return (
-      <div className="p-2">
-        <Card className="mb-2 p-3">
-          <p className="text-sm text-muted-foreground">履歴を読み込み中...</p>
-        </Card>
-      </div>
-    );
+    return <LoadingView />;
   }
 
   if (clipboardItems.length === 0) {
-    return (
-      <div className="p-2">
-        <Card className="mb-2 p-3">
-          <p className="text-sm text-muted-foreground mb-2">まだクリップボード履歴がありません。</p>
-          {process.env.NODE_ENV === "development" && (
-            <div className="flex gap-2">
-              <Button variant="outline" size="sm" onClick={handleAddTestData}>
-                テストデータ追加
-              </Button>
-            </div>
-          )}
-        </Card>
-      </div>
-    );
+    return <EmptyView onHistoryReload={onHistoryReload} />;
   }
 
   return (
@@ -218,154 +42,19 @@ export function ClipboardItemList({
       {clipboardItems.map((item, index) => {
         const isExpanded = expandedItems.has(item.id);
         const { format: currentFormat, content: currentContent } = getCurrentFormatAndContent(item);
-        const shouldTruncate = currentContent.length > 100;
-        const displayContent = isExpanded || !shouldTruncate ? currentContent : truncateText(currentContent);
 
         return (
-          <Card
+          <ClipboardItem
             key={item.id}
-            className="mb-1 p-3 hover:bg-accent hover:text-accent-foreground transition-colors border hover:border-accent-foreground/20 group"
-            onContextMenu={(e) => onContextMenu(e, item)}
-          >
-            <div className="grid grid-cols-[auto_1fr_auto] gap-3 items-start">
-              <div className="mt-0.5">
-                <span className="text-xs">{getTypeIcon(currentFormat)}</span>
-              </div>
-
-              <button
-                type="button"
-                className="min-w-0 cursor-default text-left bg-transparent border-none p-0 w-full"
-                onClick={() => onItemClick(item.id)}
-              >
-                <div className="flex items-center gap-2 mb-1">
-                  <Hash className="h-3 w-3 text-muted-foreground" />
-                  <span className="text-xs font-mono text-muted-foreground">{index + 1}</span>
-                  <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                    <Clock className="h-3 w-3" />
-                    {formatRelativeTime(item.timestamp)}
-                  </div>
-                  <span className="text-xs px-1.5 py-0.5 bg-muted rounded text-muted-foreground">
-                    {getTypeName(currentFormat)}
-                  </span>
-                </div>
-
-                {/* 複数形式バッジ */}
-                {item.available_formats && (
-                  <FormatBadges
-                    availableFormats={item.available_formats}
-                    currentFormat={currentFormat}
-                    onFormatChange={(format) => handleFormatChange(item.id, format)}
-                    mainFormat={item.content_type}
-                  />
-                )}
-
-                {/* コンテンツ表示 - 形式別の特殊表示 */}
-                {currentFormat === "text/uri-list" ? (
-                  // URL表示 - クリック可能なリンク
-                  <div className="text-sm">
-                    <button
-                      type="button"
-                      className="text-blue-500 hover:text-blue-700 underline break-words cursor-pointer text-left w-full"
-                      onClick={async (e) => {
-                        e.stopPropagation();
-                        try {
-                          await openUrl(currentContent.trim());
-                        } catch (error) {
-                          console.error("URL開く失敗:", error);
-                        }
-                      }}
-                      title={`${currentContent} を外部ブラウザで開く`}
-                    >
-                      {displayContent}
-                    </button>
-                  </div>
-                ) : currentFormat === "application/x-file-list" ? (
-                  // ファイルリスト表示 - アイコン付きリスト
-                  <div className="text-sm space-y-1">
-                    {parseFileList(currentContent)
-                      .slice(0, isExpanded ? undefined : 3)
-                      .map((file, i) => (
-                        <div key={`${file.filename}-${i}`} className="flex items-center gap-2">
-                          <span className="text-base">{file.icon}</span>
-                          <span className="break-words">{file.filename}</span>
-                        </div>
-                      ))}
-                    {!isExpanded && parseFileList(currentContent).length > 3 && (
-                      <div className="text-xs text-muted-foreground">
-                        +{parseFileList(currentContent).length - 3}個のファイル...
-                      </div>
-                    )}
-                  </div>
-                ) : currentFormat === "image/png" ? (
-                  // 画像表示
-                  <div className="text-sm">
-                    {currentContent.startsWith("data:image/") ? (
-                      <div className="space-y-2">
-                        <img
-                          src={currentContent}
-                          alt="クリップボード画像"
-                          className="max-w-full max-h-48 rounded border object-contain bg-muted cursor-pointer transition-all hover:opacity-80"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            console.log(
-                              "🖼️ 画像クリック - クリック位置表示:",
-                              currentFormat,
-                              "データ長:",
-                              currentContent.length,
-                              "位置:",
-                              e.screenX,
-                              e.screenY
-                            );
-                            handleImageWindow(currentContent, e);
-                          }}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" || e.key === " ") {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              // キーボード操作の場合は画面中央に表示
-                              const centerEvent = {
-                                screenX: window.screen.availWidth / 2,
-                                screenY: window.screen.availHeight / 2,
-                              } as React.MouseEvent;
-                              handleImageWindow(currentContent, centerEvent);
-                            }
-                          }}
-                          onError={(e) => {
-                            console.error("画像表示エラー:", e);
-                            e.currentTarget.style.display = "none";
-                          }}
-                          title="クリックで別ウィンドウ表示"
-                        />
-                        <p className="text-xs text-muted-foreground">
-                          画像データ ({Math.round(currentContent.length / 1024)}KB)
-                        </p>
-                      </div>
-                    ) : (
-                      <p className="text-muted-foreground">{displayContent}</p>
-                    )}
-                  </div>
-                ) : (
-                  // 通常のテキスト表示
-                  <p className="text-sm leading-relaxed break-words whitespace-pre-wrap">{displayContent}</p>
-                )}
-              </button>
-
-              <div className="ml-2">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 hover:bg-accent transition-opacity cursor-pointer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigator.clipboard.writeText(currentContent);
-                  }}
-                  title="クリップボードにコピー"
-                >
-                  <Copy className="h-3 w-3" />
-                </Button>
-              </div>
-            </div>
-          </Card>
+            item={item}
+            index={index}
+            isExpanded={isExpanded}
+            currentFormat={currentFormat}
+            currentContent={currentContent}
+            onItemClick={onItemClick}
+            onFormatChange={handleFormatChange}
+            onContextMenu={onContextMenu}
+          />
         );
       })}
     </div>

--- a/src/components/home/ClipboardItemList.tsx
+++ b/src/components/home/ClipboardItemList.tsx
@@ -304,12 +304,9 @@ export function ClipboardItemList({
                           }}
                           title="クリックで別ウィンドウ表示"
                         />
-                        <div className="flex items-center justify-between">
-                          <p className="text-xs text-muted-foreground">
-                            画像データ ({Math.round(currentContent.length / 1024)}KB)
-                          </p>
-                          <p className="text-xs text-muted-foreground">クリックで別ウィンドウ表示</p>
-                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          画像データ ({Math.round(currentContent.length / 1024)}KB)
+                        </p>
                       </div>
                     ) : (
                       <p className="text-muted-foreground">{displayContent}</p>

--- a/src/components/home/ClipboardItemList.tsx
+++ b/src/components/home/ClipboardItemList.tsx
@@ -182,6 +182,28 @@ export function ClipboardItemList({
                       </div>
                     )}
                   </div>
+                ) : currentFormat === "image/png" ? (
+                  // 画像表示
+                  <div className="text-sm">
+                    {currentContent.startsWith("data:image/") ? (
+                      <div className="space-y-2">
+                        <img 
+                          src={currentContent} 
+                          alt="クリップボード画像"
+                          className="max-w-full max-h-48 rounded border object-contain bg-muted"
+                          onError={(e) => {
+                            console.error("画像表示エラー:", e);
+                            e.currentTarget.style.display = "none";
+                          }}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          画像データ ({Math.round(currentContent.length / 1024)}KB)
+                        </p>
+                      </div>
+                    ) : (
+                      <p className="text-muted-foreground">{displayContent}</p>
+                    )}
+                  </div>
                 ) : (
                   // 通常のテキスト表示
                   <p className="text-sm leading-relaxed break-words whitespace-pre-wrap">{displayContent}</p>

--- a/src/components/home/ClipboardItemList.tsx
+++ b/src/components/home/ClipboardItemList.tsx
@@ -46,9 +46,9 @@ export function ClipboardItemList({
     return { format: selectedFormat, content };
   };
 
-  // 画像を別ウィンドウで表示
-  const handleImageWindow = (imageData: string) => {
-    console.log("🖼️ 画像別ウィンドウ表示:", `${imageData.substring(0, 50)}...`);
+  // 画像をクリック位置に表示
+  const handleImageWindow = (imageData: string, clickEvent: React.MouseEvent) => {
+    console.log("🖼️ 画像表示:", `${imageData.substring(0, 50)}...`);
 
     // 画像サイズを取得するための一時的なImage要素を作成
     const tempImg = new Image();
@@ -78,10 +78,34 @@ export function ClipboardItemList({
         windowHeight = windowHeight * scale;
       }
 
+      // クリック位置を基準とした表示位置を計算
+      const clickX = clickEvent.screenX;
+      const clickY = clickEvent.screenY;
+      
+      // ウィンドウがデスクトップ範囲外に出ないよう調整
+      let windowX = clickX - windowWidth / 2; // クリック位置を中央とする
+      let windowY = clickY - windowHeight / 2;
+      
+      // 画面境界チェック
+      if (windowX < 0) windowX = 0;
+      if (windowY < 0) windowY = 0;
+      if (windowX + windowWidth > screenWidth) {
+        windowX = screenWidth - windowWidth;
+      }
+      if (windowY + windowHeight > screenHeight) {
+        windowY = screenHeight - windowHeight;
+      }
+      
+      // 調整後もデスクトップ範囲外になる場合は中央表示にフォールバック
+      if (windowX < 0 || windowY < 0) {
+        windowX = (screenWidth - windowWidth) / 2;
+        windowY = (screenHeight - windowHeight) / 2;
+      }
+
       const newWindow = window.open(
         "",
         "_blank",
-        `width=${Math.round(windowWidth)},height=${Math.round(windowHeight)},scrollbars=no,resizable=yes`,
+        `width=${Math.round(windowWidth)},height=${Math.round(windowHeight)},left=${Math.round(windowX)},top=${Math.round(windowY)},scrollbars=no,resizable=yes`,
       );
       if (newWindow) {
         newWindow.document.write(`
@@ -284,18 +308,26 @@ export function ClipboardItemList({
                           onClick={(e) => {
                             e.stopPropagation();
                             console.log(
-                              "🖼️ 画像クリック - 別ウィンドウ表示:",
+                              "🖼️ 画像クリック - クリック位置表示:",
                               currentFormat,
                               "データ長:",
                               currentContent.length,
+                              "位置:",
+                              e.screenX,
+                              e.screenY
                             );
-                            handleImageWindow(currentContent);
+                            handleImageWindow(currentContent, e);
                           }}
                           onKeyDown={(e) => {
                             if (e.key === "Enter" || e.key === " ") {
                               e.preventDefault();
                               e.stopPropagation();
-                              handleImageWindow(currentContent);
+                              // キーボード操作の場合は画面中央に表示
+                              const centerEvent = {
+                                screenX: window.screen.availWidth / 2,
+                                screenY: window.screen.availHeight / 2,
+                              } as React.MouseEvent;
+                              handleImageWindow(currentContent, centerEvent);
                             }
                           }}
                           onError={(e) => {

--- a/src/components/home/ClipboardItemList.tsx
+++ b/src/components/home/ClipboardItemList.tsx
@@ -46,6 +46,92 @@ export function ClipboardItemList({
     return { format: selectedFormat, content };
   };
 
+  // 画像を別ウィンドウで表示
+  const handleImageWindow = (imageData: string) => {
+    console.log("🖼️ 画像別ウィンドウ表示:", `${imageData.substring(0, 50)}...`);
+
+    // 画像サイズを取得するための一時的なImage要素を作成
+    const tempImg = new Image();
+    tempImg.onload = () => {
+      const imgWidth = tempImg.width;
+      const imgHeight = tempImg.height;
+
+      // デスクトップサイズを取得
+      const screenWidth = window.screen.availWidth;
+      const screenHeight = window.screen.availHeight;
+
+      // ウィンドウサイズを計算（画像サイズに合わせる、ただしデスクトップサイズを超える場合は縮小）
+      let windowWidth = imgWidth;
+      let windowHeight = imgHeight;
+
+      // デスクトップサイズの90%を最大値とする
+      const maxWidth = screenWidth * 0.9;
+      const maxHeight = screenHeight * 0.9;
+
+      // 縦横どちらかがデスクトップサイズを超える場合、アスペクト比を維持して縮小
+      if (windowWidth > maxWidth || windowHeight > maxHeight) {
+        const scaleWidth = maxWidth / windowWidth;
+        const scaleHeight = maxHeight / windowHeight;
+        const scale = Math.min(scaleWidth, scaleHeight); // より小さいスケールを選択
+
+        windowWidth = windowWidth * scale;
+        windowHeight = windowHeight * scale;
+      }
+
+      const newWindow = window.open(
+        "",
+        "_blank",
+        `width=${Math.round(windowWidth)},height=${Math.round(windowHeight)},scrollbars=no,resizable=yes`,
+      );
+      if (newWindow) {
+        newWindow.document.write(`
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>ClipOne - 画像表示</title>
+            <style>
+              body { 
+                margin: 0; 
+                background: #000; 
+                display: flex; 
+                justify-content: center; 
+                align-items: center; 
+                min-height: 100vh;
+                overflow: hidden;
+              }
+              img { 
+                max-width: 100vw; 
+                max-height: 100vh; 
+                object-fit: contain;
+                cursor: pointer;
+              }
+            </style>
+          </head>
+          <body>
+            <img src="${imageData}" alt="クリップボード画像" onclick="window.close()" />
+            <script>
+              document.addEventListener('keydown', function(event) {
+                if (event.key === 'Escape') {
+                  window.close();
+                }
+              });
+              
+              document.addEventListener('click', function(event) {
+                window.close();
+              });
+            </script>
+          </body>
+          </html>
+        `);
+        newWindow.document.close();
+      } else {
+        console.error("❌ 別ウィンドウを開けませんでした（ポップアップブロックされた可能性があります）");
+      }
+    };
+
+    tempImg.src = imageData;
+  };
+
   const handleAddTestData = async () => {
     try {
       const result = await invoke("add_test_data");
@@ -104,7 +190,7 @@ export function ClipboardItemList({
   }
 
   return (
-    <div className="p-2">
+    <div className="p-2 relative">
       {clipboardItems.map((item, index) => {
         const isExpanded = expandedItems.has(item.id);
         const { format: currentFormat, content: currentContent } = getCurrentFormatAndContent(item);
@@ -122,7 +208,11 @@ export function ClipboardItemList({
                 <span className="text-xs">{getTypeIcon(currentFormat)}</span>
               </div>
 
-              <div className="min-w-0 cursor-default text-left" onClick={() => onItemClick(item.id)}>
+              <button
+                type="button"
+                className="min-w-0 cursor-default text-left bg-transparent border-none p-0 w-full"
+                onClick={() => onItemClick(item.id)}
+              >
                 <div className="flex items-center gap-2 mb-1">
                   <Hash className="h-3 w-3 text-muted-foreground" />
                   <span className="text-xs font-mono text-muted-foreground">{index + 1}</span>
@@ -171,7 +261,7 @@ export function ClipboardItemList({
                     {parseFileList(currentContent)
                       .slice(0, isExpanded ? undefined : 3)
                       .map((file, i) => (
-                        <div key={i} className="flex items-center gap-2">
+                        <div key={`${file.filename}-${i}`} className="flex items-center gap-2">
                           <span className="text-base">{file.icon}</span>
                           <span className="break-words">{file.filename}</span>
                         </div>
@@ -187,18 +277,39 @@ export function ClipboardItemList({
                   <div className="text-sm">
                     {currentContent.startsWith("data:image/") ? (
                       <div className="space-y-2">
-                        <img 
-                          src={currentContent} 
+                        <img
+                          src={currentContent}
                           alt="クリップボード画像"
-                          className="max-w-full max-h-48 rounded border object-contain bg-muted"
+                          className="max-w-full max-h-48 rounded border object-contain bg-muted cursor-pointer transition-all hover:opacity-80"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            console.log(
+                              "🖼️ 画像クリック - 別ウィンドウ表示:",
+                              currentFormat,
+                              "データ長:",
+                              currentContent.length,
+                            );
+                            handleImageWindow(currentContent);
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              handleImageWindow(currentContent);
+                            }
+                          }}
                           onError={(e) => {
                             console.error("画像表示エラー:", e);
                             e.currentTarget.style.display = "none";
                           }}
+                          title="クリックで別ウィンドウ表示"
                         />
-                        <p className="text-xs text-muted-foreground">
-                          画像データ ({Math.round(currentContent.length / 1024)}KB)
-                        </p>
+                        <div className="flex items-center justify-between">
+                          <p className="text-xs text-muted-foreground">
+                            画像データ ({Math.round(currentContent.length / 1024)}KB)
+                          </p>
+                          <p className="text-xs text-muted-foreground">クリックで別ウィンドウ表示</p>
+                        </div>
                       </div>
                     ) : (
                       <p className="text-muted-foreground">{displayContent}</p>
@@ -208,7 +319,7 @@ export function ClipboardItemList({
                   // 通常のテキスト表示
                   <p className="text-sm leading-relaxed break-words whitespace-pre-wrap">{displayContent}</p>
                 )}
-              </div>
+              </button>
 
               <div className="ml-2">
                 <Button

--- a/src/components/home/ClipboardStateViews.tsx
+++ b/src/components/home/ClipboardStateViews.tsx
@@ -1,0 +1,74 @@
+import { invoke } from "@tauri-apps/api/core";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+interface StateViewProps {
+  onHistoryReload: () => Promise<void>;
+}
+
+export function ErrorView({ error, onHistoryReload }: { error: string } & StateViewProps) {
+  const handleAddTestData = async () => {
+    try {
+      const result = await invoke("add_test_data");
+      console.log("テストデータ追加結果:", result);
+      await onHistoryReload();
+    } catch (err) {
+      console.error("テストデータ追加エラー:", err);
+    }
+  };
+
+  return (
+    <div className="p-2">
+      <Card className="mb-2 p-3 border-red-200 bg-red-50 text-red-800">
+        <p className="text-sm">{error}</p>
+        <div className="flex gap-2 mt-2">
+          <Button variant="outline" size="sm" onClick={onHistoryReload}>
+            再試行
+          </Button>
+          {process.env.NODE_ENV === "development" && (
+            <Button variant="outline" size="sm" onClick={handleAddTestData}>
+              テストデータ追加
+            </Button>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export function LoadingView() {
+  return (
+    <div className="p-2">
+      <Card className="mb-2 p-3">
+        <p className="text-sm text-muted-foreground">履歴を読み込み中...</p>
+      </Card>
+    </div>
+  );
+}
+
+export function EmptyView({ onHistoryReload }: StateViewProps) {
+  const handleAddTestData = async () => {
+    try {
+      const result = await invoke("add_test_data");
+      console.log("テストデータ追加結果:", result);
+      await onHistoryReload();
+    } catch (err) {
+      console.error("テストデータ追加エラー:", err);
+    }
+  };
+
+  return (
+    <div className="p-2">
+      <Card className="mb-2 p-3">
+        <p className="text-sm text-muted-foreground mb-2">まだクリップボード履歴がありません。</p>
+        {process.env.NODE_ENV === "development" && (
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={handleAddTestData}>
+              テストデータ追加
+            </Button>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/hooks/useClipboardControl.ts
+++ b/src/hooks/useClipboardControl.ts
@@ -1,0 +1,54 @@
+import { useCallback } from "react";
+import { emit } from "@tauri-apps/api/event";
+
+/**
+ * クリップボード制御のカスタムフック
+ * イベントベースでRust側に明示的にコピーアクションを通知
+ */
+export function useClipboardControl() {
+  // コピーアクション開始を通知
+  const notifyStartCopy = useCallback(async (content: string, source: string = "ui") => {
+    try {
+      await emit("copy-action-start", { content, source, timestamp: Date.now() });
+      console.log(`📤 コピーアクション開始通知: ${source}`);
+    } catch (error) {
+      console.error("❌ コピー開始通知エラー:", error);
+    }
+  }, []);
+
+  // コピーアクション完了を通知
+  const notifyEndCopy = useCallback(async (content: string, source: string = "ui") => {
+    try {
+      await emit("copy-action-end", { content, source, timestamp: Date.now() });
+      console.log(`📥 コピーアクション完了通知: ${source}`);
+    } catch (error) {
+      console.error("❌ コピー完了通知エラー:", error);
+    }
+  }, []);
+
+  // 安全なコピー実行（通知付き）
+  const safeExecuteCopy = useCallback(async <T>(
+    content: string,
+    copyAction: () => Promise<T>,
+    source: string = "ui"
+  ): Promise<T> => {
+    await notifyStartCopy(content, source);
+    
+    try {
+      const result = await copyAction();
+      // コピー完了を即座に通知
+      await notifyEndCopy(content, source);
+      return result;
+    } catch (error) {
+      // エラーが発生した場合でも完了通知を送信
+      await notifyEndCopy(content, source);
+      throw error;
+    }
+  }, [notifyStartCopy, notifyEndCopy]);
+
+  return {
+    notifyStartCopy,
+    notifyEndCopy,
+    safeExecuteCopy,
+  };
+}

--- a/src/hooks/useClipboardFormats.ts
+++ b/src/hooks/useClipboardFormats.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from "react";
+import type { DisplayClipboardItem } from "@/types/clipboardActions";
+
+/**
+ * クリップボードアイテムのフォーマット管理フック
+ */
+export function useClipboardFormats() {
+  // 各アイテムの選択された形式を管理
+  const [selectedFormats, setSelectedFormats] = useState<Record<string, string>>({});
+
+  // 形式切り替えハンドラー
+  const handleFormatChange = useCallback((itemId: string, format: string) => {
+    setSelectedFormats((prev) => ({
+      ...prev,
+      [itemId]: format,
+    }));
+  }, []);
+
+  // アイテムの現在の形式とコンテンツを取得
+  const getCurrentFormatAndContent = useCallback((item: DisplayClipboardItem) => {
+    const selectedFormat = selectedFormats[item.id] || item.content_type;
+    const content = item.format_contents?.[selectedFormat] || item.content;
+    return { format: selectedFormat, content };
+  }, [selectedFormats]);
+
+  return {
+    selectedFormats,
+    handleFormatChange,
+    getCurrentFormatAndContent,
+  };
+}

--- a/src/hooks/useImageCopy.ts
+++ b/src/hooks/useImageCopy.ts
@@ -1,0 +1,46 @@
+import { useCallback } from "react";
+import { useClipboardControl } from "./useClipboardControl";
+
+/**
+ * 画像データをクリップボードにコピーするカスタムフック
+ */
+export function useImageCopy() {
+  const { safeExecuteCopy } = useClipboardControl();
+
+  const copyImageToClipboard = useCallback(async (base64DataUrl: string) => {
+    return await safeExecuteCopy(
+      base64DataUrl,
+      async () => {
+
+        try {
+          // Base64データURLから実際のバイナリデータを取得
+          const response = await fetch(base64DataUrl);
+          const blob = await response.blob();
+          
+          // ClipboardItem を使用して画像データをクリップボードにコピー
+          const clipboardItem = new ClipboardItem({
+            [blob.type]: blob
+          });
+          
+          await navigator.clipboard.write([clipboardItem]);
+          console.log("✅ 画像をクリップボードにコピーしました");
+          
+        } catch (error) {
+          console.error("❌ 画像コピーエラー:", error);
+          
+          // フォールバック: Base64文字列をテキストとしてコピー
+          try {
+            await navigator.clipboard.writeText(base64DataUrl);
+            console.log("⚠️ フォールバック: Base64文字列をテキストとしてコピーしました");
+          } catch (fallbackError) {
+            console.error("❌ フォールバックコピーエラー:", fallbackError);
+            throw new Error("画像のコピーに失敗しました");
+          }
+        }
+      },
+      "image-copy"
+    );
+  }, [safeExecuteCopy]);
+
+  return { copyImageToClipboard };
+}

--- a/src/hooks/useImageWindow.ts
+++ b/src/hooks/useImageWindow.ts
@@ -1,0 +1,117 @@
+import { useCallback } from "react";
+
+/**
+ * 画像をクリック位置にポップアップウィンドウで表示するカスタムフック
+ */
+export function useImageWindow() {
+  const showImageWindow = useCallback((imageData: string, clickEvent: React.MouseEvent) => {
+    console.log("🖼️ 画像表示:", `${imageData.substring(0, 50)}...`);
+
+    // 画像サイズを取得するための一時的なImage要素を作成
+    const tempImg = new Image();
+    tempImg.onload = () => {
+      const imgWidth = tempImg.width;
+      const imgHeight = tempImg.height;
+
+      // デスクトップサイズを取得
+      const screenWidth = window.screen.availWidth;
+      const screenHeight = window.screen.availHeight;
+
+      // ウィンドウサイズを計算（画像サイズに合わせる、ただしデスクトップサイズを超える場合は縮小）
+      let windowWidth = imgWidth;
+      let windowHeight = imgHeight;
+
+      // デスクトップサイズの90%を最大値とする
+      const maxWidth = screenWidth * 0.9;
+      const maxHeight = screenHeight * 0.9;
+
+      // 縦横どちらかがデスクトップサイズを超える場合、アスペクト比を維持して縮小
+      if (windowWidth > maxWidth || windowHeight > maxHeight) {
+        const scaleWidth = maxWidth / windowWidth;
+        const scaleHeight = maxHeight / windowHeight;
+        const scale = Math.min(scaleWidth, scaleHeight); // より小さいスケールを選択
+
+        windowWidth = windowWidth * scale;
+        windowHeight = windowHeight * scale;
+      }
+
+      // クリック位置を基準とした表示位置を計算
+      const clickX = clickEvent.screenX;
+      const clickY = clickEvent.screenY;
+      
+      // ウィンドウがデスクトップ範囲外に出ないよう調整
+      let windowX = clickX - windowWidth / 2; // クリック位置を中央とする
+      let windowY = clickY - windowHeight / 2;
+      
+      // 画面境界チェック
+      if (windowX < 0) windowX = 0;
+      if (windowY < 0) windowY = 0;
+      if (windowX + windowWidth > screenWidth) {
+        windowX = screenWidth - windowWidth;
+      }
+      if (windowY + windowHeight > screenHeight) {
+        windowY = screenHeight - windowHeight;
+      }
+      
+      // 調整後もデスクトップ範囲外になる場合は中央表示にフォールバック
+      if (windowX < 0 || windowY < 0) {
+        windowX = (screenWidth - windowWidth) / 2;
+        windowY = (screenHeight - windowHeight) / 2;
+      }
+
+      const newWindow = window.open(
+        "",
+        "_blank",
+        `width=${Math.round(windowWidth)},height=${Math.round(windowHeight)},left=${Math.round(windowX)},top=${Math.round(windowY)},scrollbars=no,resizable=yes`,
+      );
+      if (newWindow) {
+        newWindow.document.write(`
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>ClipOne - 画像表示</title>
+            <style>
+              body { 
+                margin: 0; 
+                background: #000; 
+                display: flex; 
+                justify-content: center; 
+                align-items: center; 
+                min-height: 100vh;
+                overflow: hidden;
+              }
+              img { 
+                max-width: 100vw; 
+                max-height: 100vh; 
+                object-fit: contain;
+                cursor: pointer;
+              }
+            </style>
+          </head>
+          <body>
+            <img src="${imageData}" alt="クリップボード画像" onclick="window.close()" />
+            <script>
+              document.addEventListener('keydown', function(event) {
+                if (event.key === 'Escape') {
+                  window.close();
+                }
+              });
+              
+              document.addEventListener('click', function(event) {
+                window.close();
+              });
+            </script>
+          </body>
+          </html>
+        `);
+        newWindow.document.close();
+      } else {
+        console.error("❌ 別ウィンドウを開けませんでした（ポップアップブロックされた可能性があります）");
+      }
+    };
+
+    tempImg.src = imageData;
+  }, []);
+
+  return { showImageWindow };
+}

--- a/src/hooks/useTextCopy.ts
+++ b/src/hooks/useTextCopy.ts
@@ -1,0 +1,27 @@
+import { useCallback } from "react";
+import { useClipboardControl } from "./useClipboardControl";
+
+/**
+ * テキストデータをクリップボードにコピーするカスタムフック（監視一時停止付き）
+ */
+export function useTextCopy() {
+  const { safeExecuteCopy } = useClipboardControl();
+
+  const copyTextToClipboard = useCallback(async (text: string) => {
+    return await safeExecuteCopy(
+      text,
+      async () => {
+        try {
+          await navigator.clipboard.writeText(text);
+          console.log("✅ テキストをクリップボードにコピーしました");
+        } catch (error) {
+          console.error("❌ テキストコピーエラー:", error);
+          throw new Error("テキストのコピーに失敗しました");
+        }
+      },
+      "text-copy"
+    );
+  }, [safeExecuteCopy]);
+
+  return { copyTextToClipboard };
+}


### PR DESCRIPTION
## 概要
画像データの取得、表示、およびコピー機能を包括的に実装。日本語テキスト処理のランタイムエラーも修正。

## 関連 Issue
Closes #18

## 変更内容

### 🖼️ 画像処理機能
- Base64画像データ変換とData URL生成
- クリック位置ベースの画像ウィンドウ表示
- 画像専用コピー機能（ClipboardItem API使用）
- 画像サイズ制限（5MB）とエラーハンドリング

### 🎛️ ユーザーインターフェース
- ホバーから別ウィンドウクリック式表示に変更
- コンポーネント機能分割リファクタリング（374行→62行、83%削減）
- クリック位置計算とデスクトップ範囲内調整
- キーボードアクセシビリティ対応

### 🔧 システム制御
- イベントベースクリップボード監視制御
- 重複検出ロジック強化（コピーボタン対策）
- UTF-8文字境界安全な文字列処理
- Windows OSError(0)特別処理

### 🏗️ アーキテクチャ改善
- カスタムフック分離（useImageWindow, useClipboardControl等）
- コンポーネント責任分離（ClipboardItem, ClipboardContentRenderer等）
- 型安全性とエラーハンドリング強化

## テスト
- [x] 画像データ取得とBase64変換
- [x] クリック位置ベース画像ウィンドウ表示
- [x] 画像/テキスト別コピー機能
- [x] 日本語テキスト処理（文字境界エラー修正確認）
- [x] コンポーネントリファクタリング検証
- [x] Rust clippy警告解消
- [x] TypeScript型チェック通過

🤖 Generated with [Claude Code](https://claude.ai/code)