### PR TITLE
アプリ情報機能の実装（バージョン・ライセンス情報）

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "clip-one"
 version = "0.2.0"
-description = "A Tauri App"
-authors = ["you"]
+description = "ClipOne - クリップボード履歴管理アプリケーション"
+authors = ["masinc"]
 edition = "2021"
+license = "MIT"
+repository = "https://github.com/masinc/clip-one"
+homepage = "https://github.com/masinc/clip-one"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,10 +18,11 @@ fn setup_system_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>>
     let show_hide = MenuItem::with_id(app, "toggle_window", "履歴の表示/非表示", true, None::<&str>)?;
     let separator1 = PredefinedMenuItem::separator(app)?;
     let settings = MenuItem::with_id(app, "settings", "設定", true, None::<&str>)?;
+    let about = MenuItem::with_id(app, "about", "ClipOne について", true, None::<&str>)?;
     let separator2 = PredefinedMenuItem::separator(app)?;
     let quit = MenuItem::with_id(app, "quit", "終了", true, None::<&str>)?;
     
-    let menu = Menu::with_items(app, &[&show_hide, &separator1, &settings, &separator2, &quit])?;
+    let menu = Menu::with_items(app, &[&show_hide, &separator1, &settings, &about, &separator2, &quit])?;
     
     // トレイアイコンを作成（既存の32x32アイコンを使用）
     let icon_bytes = include_bytes!("../icons/32x32.png");
@@ -85,6 +86,17 @@ fn setup_system_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>>
                         let _ = window.set_focus();
                         // 設定ページに遷移するイベントを送信
                         let _ = window.emit("tray-navigate-settings", ());
+                    }
+                }
+                "about" => {
+                    // アバウト画面を表示
+                    if let Some(window) = app.get_webview_window("main") {
+                        // まずウィンドウを表示
+                        WINDOW_SHOULD_BE_VISIBLE.store(true, Ordering::Relaxed);
+                        let _ = window.show();
+                        let _ = window.set_focus();
+                        // アバウトページに遷移するイベントを送信
+                        let _ = window.emit("tray-navigate-about", ());
                     }
                 }
                 "quit" => {
@@ -198,6 +210,8 @@ pub fn run() {
             save_app_settings,
             update_setting,
             reset_settings,
+            // アプリ情報
+            get_app_info,
             // エクスポート/インポート
             export_clipboard_history_json,
             export_clipboard_history_csv,

--- a/src/components/home/HomeHeader.tsx
+++ b/src/components/home/HomeHeader.tsx
@@ -56,7 +56,7 @@ export function HomeHeader({ searchQuery, onSearchChange, onHistoryReload }: Hom
                   履歴をクリア
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem>
+                <DropdownMenuItem onClick={() => navigate("/about")}>
                   <Info className="h-4 w-4" />
                   ClipOne について
                 </DropdownMenuItem>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,29 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive: "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { ArrowLeft, Code, FileText, Github, Heart } from "lucide-react";
+import { ArrowLeft, Code, Github, Heart } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { Badge } from "@/components/ui/badge";

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { ArrowLeft, Code, FileText, Github, Heart } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
@@ -186,7 +187,7 @@ const About = () => {
           <CardHeader>
             <CardTitle>関連リンク</CardTitle>
           </CardHeader>
-          <CardContent className="space-y-3">
+          <CardContent>
             {appInfo?.repository && (
               <Button
                 variant="outline"
@@ -194,7 +195,7 @@ const About = () => {
                 onClick={async () => {
                   if (appInfo?.repository) {
                     try {
-                      await invoke("plugin:opener|open", { url: appInfo.repository });
+                      await openUrl(appInfo.repository);
                     } catch (error) {
                       console.error("リポジトリを開けませんでした:", error);
                     }
@@ -203,22 +204,6 @@ const About = () => {
               >
                 <Github className="h-4 w-4 mr-2" />
                 GitHub リポジトリ
-              </Button>
-            )}
-
-            {appInfo?.license && (
-              <Button
-                variant="outline"
-                className="w-full justify-start"
-                onClick={() => {
-                  // TODO: ライセンス詳細ダイアログを表示
-                  alert(
-                    `ライセンス: ${appInfo.license}\n\n詳細なライセンス情報については、GitHubリポジトリをご確認ください。`,
-                  );
-                }}
-              >
-                <FileText className="h-4 w-4 mr-2" />
-                ライセンス情報
               </Button>
             )}
           </CardContent>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,245 @@
+import { invoke } from "@tauri-apps/api/core";
+import { ArrowLeft, Code, FileText, Github, Heart } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { AppInfo } from "@/types/clipboard";
+
+const About = () => {
+  const navigate = useNavigate();
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // アプリ情報を取得
+  useEffect(() => {
+    const loadAppInfo = async () => {
+      try {
+        const info = await invoke<AppInfo>("get_app_info");
+        setAppInfo(info);
+      } catch (error) {
+        console.error("アプリ情報の取得に失敗:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadAppInfo();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-muted-foreground">アプリ情報を読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <div className="border-b">
+        <div className="flex items-center gap-3 p-4">
+          <Button variant="ghost" size="icon" onClick={() => navigate("/")} className="h-8 w-8">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <h1 className="text-lg font-semibold">ClipOne について</h1>
+        </div>
+      </div>
+
+      {/* About Content */}
+      <div className="p-6 space-y-6 max-w-2xl mx-auto">
+        {/* アプリロゴ・タイトル */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center space-y-4">
+              <div className="w-16 h-16 bg-primary rounded-lg flex items-center justify-center mx-auto">
+                <span className="text-2xl font-bold text-primary-foreground">C</span>
+              </div>
+              <div>
+                <h2 className="text-2xl font-bold">{appInfo?.name || "ClipOne"}</h2>
+                <p className="text-muted-foreground">
+                  {appInfo?.description || "クリップボード履歴管理アプリケーション"}
+                </p>
+              </div>
+              <div className="flex justify-center">
+                <Badge variant="secondary" className="text-sm">
+                  Version {appInfo?.version || "0.0.0"}
+                </Badge>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* アプリ詳細情報 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>アプリケーション情報</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 gap-3">
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">アプリ名</span>
+                <span className="font-medium">{appInfo?.name || "ClipOne"}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">バージョン</span>
+                <span className="font-medium">{appInfo?.version || "0.0.0"}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">作者</span>
+                <span className="font-medium">{appInfo?.author || "Unknown"}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">ビルド日</span>
+                <span className="font-medium">{appInfo?.build_date || "Unknown"}</span>
+              </div>
+              {appInfo?.license && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">ライセンス</span>
+                  <span className="font-medium">{appInfo.license}</span>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 技術スタック */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Code className="h-5 w-5" />
+              技術スタック
+            </CardTitle>
+            <CardDescription>ClipOneの構築に使用された技術</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <h4 className="font-medium text-sm">フロントエンド</h4>
+                <div className="space-y-1 text-sm text-muted-foreground">
+                  <div>• React 18</div>
+                  <div>• TypeScript</div>
+                  <div>• Tailwind CSS</div>
+                  <div>• shadcn/ui</div>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <h4 className="font-medium text-sm">バックエンド</h4>
+                <div className="space-y-1 text-sm text-muted-foreground">
+                  <div>• Tauri v2</div>
+                  <div>• Rust</div>
+                  <div>• SQLite</div>
+                  <div>• clipboard-rs</div>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 機能紹介 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>主な機能</CardTitle>
+            <CardDescription>ClipOneで利用できる機能</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3 text-sm">
+              <div className="flex items-start gap-3">
+                <div className="w-2 h-2 bg-primary rounded-full mt-2 flex-shrink-0"></div>
+                <div>
+                  <strong>クリップボード履歴管理</strong>
+                  <div className="text-muted-foreground">コピーした内容を自動的に保存し、履歴から簡単に再利用</div>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <div className="w-2 h-2 bg-primary rounded-full mt-2 flex-shrink-0"></div>
+                <div>
+                  <strong>システムトレイ常駐</strong>
+                  <div className="text-muted-foreground">バックグラウンドで動作し、必要な時にすぐアクセス可能</div>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <div className="w-2 h-2 bg-primary rounded-full mt-2 flex-shrink-0"></div>
+                <div>
+                  <strong>複数形式対応</strong>
+                  <div className="text-muted-foreground">テキスト、画像、ファイルなど多様な形式をサポート</div>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <div className="w-2 h-2 bg-primary rounded-full mt-2 flex-shrink-0"></div>
+                <div>
+                  <strong>検索・フィルタ</strong>
+                  <div className="text-muted-foreground">履歴の検索と絞り込みで効率的な履歴管理</div>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* リンク集 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>関連リンク</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {appInfo?.repository && (
+              <Button
+                variant="outline"
+                className="w-full justify-start"
+                onClick={async () => {
+                  if (appInfo?.repository) {
+                    try {
+                      await invoke("plugin:opener|open", { url: appInfo.repository });
+                    } catch (error) {
+                      console.error("リポジトリを開けませんでした:", error);
+                    }
+                  }
+                }}
+              >
+                <Github className="h-4 w-4 mr-2" />
+                GitHub リポジトリ
+              </Button>
+            )}
+
+            {appInfo?.license && (
+              <Button
+                variant="outline"
+                className="w-full justify-start"
+                onClick={() => {
+                  // TODO: ライセンス詳細ダイアログを表示
+                  alert(
+                    `ライセンス: ${appInfo.license}\n\n詳細なライセンス情報については、GitHubリポジトリをご確認ください。`,
+                  );
+                }}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                ライセンス情報
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* フッター */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center space-y-2">
+              <div className="flex items-center justify-center gap-1 text-sm text-muted-foreground">
+                <span>Made with</span>
+                <Heart className="h-4 w-4 text-red-500" />
+                <span>by {appInfo?.author || "Unknown"}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">© 2024 ClipOne. すべての権利は留保されています。</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default About;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -125,7 +125,7 @@ export default function Home() {
         });
 
         // アバウトページナビゲーションイベント
-        const _unlistenAbout = await listen("tray-navigate-about", () => {
+        await listen("tray-navigate-about", () => {
           console.log("ℹ️ トレイからアバウト画面遷移要求を受信");
           navigate("/about");
         });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -78,7 +78,6 @@ export default function Home() {
 
     // 直接clipboard-updatedイベントをリッスンして履歴リストを即座に更新
     let unlistenClipboardUpdated: (() => void) | null = null;
-    let unlistenTrayEvents: (() => void) | null = null;
     let unlistenNavigationEvents: (() => void) | null = null;
 
     const setupDirectEventListener = async () => {
@@ -124,7 +123,13 @@ export default function Home() {
           console.log("⚙️ トレイから設定画面遷移要求を受信");
           navigate("/settings");
         });
-        
+
+        // アバウトページナビゲーションイベント
+        const _unlistenAbout = await listen("tray-navigate-about", () => {
+          console.log("ℹ️ トレイからアバウト画面遷移要求を受信");
+          navigate("/about");
+        });
+
         console.log("✅ ナビゲーションイベントリスナー設定完了");
       } catch (err) {
         console.error("❌ ナビゲーションイベントリスナー設定エラー:", err);
@@ -160,9 +165,6 @@ export default function Home() {
       clearTimeout(timer);
       if (unlistenClipboardUpdated) {
         unlistenClipboardUpdated();
-      }
-      if (unlistenTrayEvents) {
-        unlistenTrayEvents();
       }
       if (unlistenNavigationEvents) {
         unlistenNavigationEvents();

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,16 +1,4 @@
-import {
-  ArrowLeft,
-  Database,
-  Download,
-  Eye,
-  FileText,
-  Monitor,
-  Moon,
-  RotateCcw,
-  Sun,
-  Trash2,
-  Upload,
-} from "lucide-react";
+import { ArrowLeft, Database, Download, Eye, Monitor, Moon, RotateCcw, Sun, Trash2, Upload } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
@@ -204,28 +192,6 @@ const Settings = () => {
                 設定をリセット
               </Button>
             </div>
-          </CardContent>
-        </Card>
-
-        {/* アプリ情報 */}
-        <Card>
-          <CardHeader>
-            <CardTitle>アプリ情報</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">バージョン</span>
-              <span>1.0.0</span>
-            </div>
-            <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">ビルド</span>
-              <span>2024.12.21</span>
-            </div>
-            <Separator className="my-3" />
-            <Button variant="outline" className="w-full justify-start">
-              <FileText className="h-4 w-4 mr-2" />
-              ライセンス情報
-            </Button>
           </CardContent>
         </Card>
       </div>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from "react-router";
 import App from "./App";
+import About from "./pages/About";
 import ActionsSettings from "./pages/ActionsSettings";
 import Home from "./pages/Home";
 import Settings from "./pages/Settings";
@@ -20,6 +21,10 @@ export const router = createBrowserRouter([
       {
         path: "actions-settings",
         element: <ActionsSettings />,
+      },
+      {
+        path: "about",
+        element: <About />,
       },
     ],
   },

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -36,9 +36,20 @@ export interface ExportData {
   items: ClipboardItem[];
 }
 
-// アプリケーション設定の型定義
+// アプリケーション情報の型定義
+export interface AppInfo {
+  name: string; // アプリ名
+  version: string; // バージョン（Cargo.tomlから）
+  description: string; // アプリ説明
+  author: string; // 作者
+  license?: string; // ライセンス
+  repository?: string; // リポジトリURL
+  homepage?: string; // ホームページ
+  build_date: string; // ビルド日時
+}
+
+// アプリケーション設定の型定義（versionフィールドを削除）
 export interface AppSettings {
-  version: string;
   auto_start: boolean;
   max_history_items: number;
   hotkeys: Record<string, string>;


### PR DESCRIPTION
## 概要
設定からバージョン情報を分離し、包括的なアプリ情報機能を実装しました。

## 関連Issue
Closes #20

## 実装内容

### 🔧 Backend (Rust)
- **AppInfo構造体追加**: アプリ名、バージョン、作者、ライセンス、リポジトリ情報
- **get_app_info API**: Cargo.tomlから動的に情報を取得
- **設定の簡素化**: AppSettingsからversionフィールドを削除

### 🎨 Frontend (React)  
- **専用Aboutページ**: `/about` ルートで美しいUI表示
- **動的情報表示**: Cargo.tomlから取得した正確な情報
- **技術スタック紹介**: 使用技術とアプリ機能の説明
- **外部リンク**: GitHubリポジトリへのリンク（標準ブラウザで開く）

### 🚀 UI/UX改善
- **2つのアクセス方法**:
  - トップ画面メニュー: 右上「...」→「ClipOne について」
  - システムトレイ: 右クリック→「ClipOne について」
- **設定画面の整理**: アプリ情報セクションを削除し設定項目を整理

### 📋 技術改善
- Cargo.tomlメタデータの充実（license, repository, homepage）
- TypeScript型定義の追加（AppInfo）
- 適切なエラーハンドリング
- コードクリーンアップ

## テスト結果
- [x] トップ画面メニューからのアクセス
- [x] システムトレイメニューからのアクセス  
- [x] アプリ情報の正確な表示
- [x] GitHubリンクの動作
- [x] レスポンシブデザイン

🤖 Generated with [Claude Code](https://claude.ai/code)